### PR TITLE
Add reference to support for Pico CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ To begin using this template, choose one of the following options to get started
 * Clone the repo: `git clone https://github.com/BlackrockDigital/startbootstrap-simple-sidebar.git`
 * Fork the repo
 
+## Support for Pico CMS
+
+[Start Bootstrap](http://startbootstrap.com/) - [Simple Sidebar](http://startbootstrap.com/template-overviews/simple-sidebar/) can be used with [Pico CMS](http://picocms) through the ported [bt-theme](https://github.com/dmelo/bt-theme) project.
+
 ## Bugs and Issues
 
 Have a bug or an issue with this template? [Open a new issue](https://github.com/BlackrockDigital/startbootstrap-simple-sidebar/issues) here on GitHub or leave a comment on the [template overview page at Start Bootstrap](http://startbootstrap.com/template-overviews/simple-sidebar/).


### PR DESCRIPTION
I really liked the simplicity of the theme. I've been using it on my site (http://diogomelo.net) for a while now. Behind the scenes, I use Pico CMS, which I also admire for its simplicity.

In order to use startbootstrap-simple-sidebar on Pico, I had to port it. Thus, i've created the project bt-theme, which is pure startbootstrap-simple-sidebar ported to Pico, I think it is a good idea to mention it on this project. I'm only not sure if my PR provides the best way to do it.
