### PR TITLE
fix: set overflow on wrapper instead of body element

### DIFF
--- a/css/simple-sidebar.css
+++ b/css/simple-sidebar.css
@@ -3,9 +3,10 @@
  * Copyright 2013-2019 Start Bootstrap
  * Licensed under MIT (https://github.com/BlackrockDigital/startbootstrap-simple-sidebar/blob/master/LICENSE)
  */
-body {
-  overflow-x: hidden;
-}
+
+ #wrapper {
+    overflow-x: hidden;
+ }
 
 #sidebar-wrapper {
   min-height: 100vh;


### PR DESCRIPTION
Instead of setting overflow on the body element, this targets the "wrapper" container since you wouldn't necessarily target the body in a big project.